### PR TITLE
Set up Amazon-2 vagrant

### DIFF
--- a/ansible/vagrant-inventory/hosts.yml
+++ b/ansible/vagrant-inventory/hosts.yml
@@ -33,3 +33,8 @@ all:
           ansible_port: 22
           ansible_user: vagrant
           ansible_ssh_private_key_file: ../vagrant/debian-12/.vagrant/machines/vagrant-debian-12/virtualbox/private_key
+        amzn-2:
+          ansible_host: 192.168.56.9
+          ansible_port: 22
+          ansible_user: vagrant
+          ansible_ssh_private_key_file: ../vagrant/amzn-2/.vagrant/machines/vagrant-amzn-2/virtualbox/private_key

--- a/vagrant/amzn-2/Vagrantfile
+++ b/vagrant/amzn-2/Vagrantfile
@@ -1,0 +1,76 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "gbailey/amzn2"
+  config.vm.define "vagrant-amzn-2"
+  config.vm.network "private_network", ip: "192.168.56.9"
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "../bootstrap.yml"
+  end
+
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end

--- a/vagrant/bootstrap.yml
+++ b/vagrant/bootstrap.yml
@@ -2,16 +2,16 @@
   become: true
   hosts: all
   tasks:
-    - name: Ubuntu apt update
+    - name: Ubuntu and Debian apt update
       ansible.builtin.apt:
         state: latest
         name: '*'
         update-cache: true
       when: ansible_distribution in ["Ubuntu", "Debian"]
 
-    - name: Rocky and CentOS yum update
+    - name: Rocky, CentOS and Amazon yum update
       ansible.builtin.package:
         state: latest
         name: '*'
         update_cache: true
-      when: ansible_distribution in ['Rocky', 'CentOS']
+      when: ansible_distribution in ['Rocky', 'CentOS', 'Amazon']


### PR DESCRIPTION
- Received this error when running test playbook against vagrant:
```
TASK [Gathering Facts] **********************************************************************************************************************************
[WARNING]: Platform linux on host amzn-2 is using the discovered Python interpreter at /usr/bin/python2.7, but future installation of another Python
interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-core/2.16/reference_appendices/interpreter_discovery.html for
more information.
ok: [amzn-2]
```

- T'was still able to execute playboook against amzn-2 vagrant. I'll troubleshoot this at a later time when needed, saving in git for now.