### PR TITLE
Created OrcaleLinux vagrant.

### DIFF
--- a/ansible/vagrant-inventory/hosts.yml
+++ b/ansible/vagrant-inventory/hosts.yml
@@ -38,3 +38,8 @@ all:
           ansible_port: 22
           ansible_user: vagrant
           ansible_ssh_private_key_file: ../vagrant/amzn-2/.vagrant/machines/vagrant-amzn-2/virtualbox/private_key
+        oracle-9:
+          ansible_host: 192.168.56.10
+          ansible_port: 22
+          ansible_user: vagrant
+          ansible_ssh_private_key_file: ../vagrant/oracle-9/.vagrant/machines/vagrant-oracle-9/virtualbox/private_key

--- a/vagrant/bootstrap.yml
+++ b/vagrant/bootstrap.yml
@@ -2,6 +2,7 @@
   become: true
   hosts: all
   tasks:
+
     - name: Ubuntu and Debian apt update
       ansible.builtin.apt:
         state: latest
@@ -9,9 +10,9 @@
         update-cache: true
       when: ansible_distribution in ["Ubuntu", "Debian"]
 
-    - name: Rocky, CentOS and Amazon yum update
+    - name: Rocky, CentOS, OracleLinux and Amazon yum update
       ansible.builtin.package:
         state: latest
         name: '*'
         update_cache: true
-      when: ansible_distribution in ['Rocky', 'CentOS', 'Amazon']
+      when: ansible_distribution in ['Rocky', 'CentOS', 'Amazon', 'OracleLinux']

--- a/vagrant/oracle-9/Vagrantfile
+++ b/vagrant/oracle-9/Vagrantfile
@@ -1,0 +1,76 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "generic/oracle9"
+  config.vm.define "vagrant-oracle-9"
+  config.vm.network "private_network", ip: "192.168.56.10"
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "../bootstrap.yml"
+  end
+
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end


### PR DESCRIPTION
- Ensured functionality of test-playbook, received python interpreter error:
```
PLAY [Test ansible connectivity and get distribution] ************************************************************************

TASK [Gathering Facts] *******************************************************************************************************
[WARNING]: Platform linux on host oracle-9 is using the discovered Python interpreter at /usr/bin/python3.9, but future
installation of another Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-
core/2.16/reference_appendices/interpreter_discovery.html for more information.
ok: [oracle-9]
```
- Keeping error in git for reference.