### PR TITLE
Created archlinux vagrant

### DIFF
--- a/ansible/vagrant-inventory/group_vars/all/ansible.yml
+++ b/ansible/vagrant-inventory/group_vars/all/ansible.yml
@@ -1,2 +1,3 @@
 ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentityAgent=/dev/null'
 ansible_user: vagrant
+ansible_python_interpreter: /usr/bin/python3

--- a/ansible/vagrant-inventory/hosts.yml
+++ b/ansible/vagrant-inventory/hosts.yml
@@ -63,3 +63,8 @@ all:
           ansible_port: 22
           ansible_user: vagrant
           ansible_ssh_private_key_file: ../vagrant/almalinux-9-3/.vagrant/machines/vagrant-almalinux-9-3/virtualbox/private_key
+        arch-linux:
+          ansible_host: 192.168.56.15
+          ansible_port: 22
+          ansible_user: vagrant
+          ansible_ssh_private_key_file: ../vagrant/arch-linux/.vagrant/machines/vagrant-arch-linux/virtualbox/private_key

--- a/vagrant/arch-linux/Vagrantfile
+++ b/vagrant/arch-linux/Vagrantfile
@@ -12,10 +12,11 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "bento/almalinux-9.3"
-  config.vm.box_version = "202401.31.0"
-  config.vm.define "vagrant-almalinux-9-3"
-  config.vm.network "private_network", ip: "192.168.56.14"
+  config.vm.box = "generic/arch"
+  config.vm.define "vagrant-arch-linux"
+  config.vm.network "private_network", ip: "192.168.56.15"
+  config.vm.provision "shell",
+    inline: "pacman -Syu --noconfirm; pacman -S python --noconfirm"
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "../bootstrap.yml"
   end

--- a/vagrant/bootstrap.yml
+++ b/vagrant/bootstrap.yml
@@ -10,6 +10,12 @@
         update_cache: true
       when: ansible_distribution == 'Alpine'
 
+    - name: Arch Linux pacman update
+      community.general.pacman:
+        update_cache: true
+        upgrade: true
+      when: ansible_distribution == 'Archlinux'
+
     - name: openSUSE zypper update
       community.general.zypper:
         state: latest


### PR DESCRIPTION
- Ensured functionality of archlinux vagrant.

- Set the ansible python interpreter as `ansible_python_interpreter: /usr/bin/python3` to suppress warnings during gathering facts.