### PR TITLE
Created fedora-39 vagrant.

### DIFF
--- a/ansible/vagrant-inventory/hosts.yml
+++ b/ansible/vagrant-inventory/hosts.yml
@@ -68,3 +68,8 @@ all:
           ansible_port: 22
           ansible_user: vagrant
           ansible_ssh_private_key_file: ../vagrant/arch-linux/.vagrant/machines/vagrant-arch-linux/virtualbox/private_key
+        fedora-39:
+          ansible_host: 192.168.56.16
+          ansible_port: 22
+          ansible_user: vagrant
+          ansible_ssh_private_key_file: ../vagrant/fedora-39/.vagrant/machines/vagrant-fedora-39/virtualbox/private_key

--- a/vagrant/bootstrap.yml
+++ b/vagrant/bootstrap.yml
@@ -30,9 +30,9 @@
         update-cache: true
       when: ansible_distribution in ['Ubuntu', 'Debian', 'Linux Mint']
 
-    - name: Rocky, CentOS, OracleLinux and Amazon yum update
+    - name: Rocky, CentOS, Amazon, OracleLinux, AlmaLinux and Fedora yum update
       package:
         state: latest
         name: '*'
         update_cache: true
-      when: ansible_distribution in ['Rocky', 'CentOS', 'Amazon', 'OracleLinux', 'AlmaLinux']
+      when: ansible_distribution in ['Rocky', 'CentOS', 'Amazon', 'OracleLinux', 'AlmaLinux', 'Fedora']

--- a/vagrant/fedora-39/Vagrantfile
+++ b/vagrant/fedora-39/Vagrantfile
@@ -1,0 +1,78 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "fedora/39-cloud-base"
+  config.vm.box_version = "39.20231031.1"
+  config.vm.define "vagrant-fedora-39"
+  config.vm.network "private_network", ip: "192.168.56.16"
+  config.vm.provision "shell",
+    inline: "ip addr add 192.168.56.16/24 dev eth1"
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "../bootstrap.yml"
+  end
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end


### PR DESCRIPTION
- I manually set the ip address on the fedora vagrant `eth1` to the desired ip address in the Vagrant file, for example:
```
3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 08:00:27:1b:a6:13 brd ff:ff:ff:ff:ff:ff
    altname enp0s8
    inet 192.168.56.135/24 brd 192.168.56.255 scope global dynamic noprefixroute eth1
       valid_lft 493sec preferred_lft 493sec
    inet 192.168.56.16/24 scope global secondary eth1
       valid_lft forever preferred_lft forever
    inet6 fe80::a770:6b3e:3028:649b/64 scope link noprefixroute
       valid_lft forever preferred_lft forever
```

- If this becomes an issue later on when doing any kinds of tests, I can revisit this setup and change.