### PR TITLE
Created put-basic-scripts role

### DIFF
--- a/ansible/put-basic-scripts-on-hosts.yml
+++ b/ansible/put-basic-scripts-on-hosts.yml
@@ -1,0 +1,7 @@
+---
+- name: Put basic scripts on hosts
+  hosts: all
+  become: true
+  roles:
+    - basic-scripts
+...

--- a/ansible/roles/basic-scripts/tasks/main.yml
+++ b/ansible/roles/basic-scripts/tasks/main.yml
@@ -1,0 +1,39 @@
+- name: Create /home/vagrant/scripts folder
+  file:
+    path: /home/vagrant/scripts
+    state: directory
+    owner: vagrant
+    group: vagrant
+    mode: '0755'
+
+- name: Create my_script.sh from .j2 template
+  template:
+    src: templates/my_script.sh.j2
+    dest: /home/vagrant/scripts/my_script.sh
+    owner: vagrant
+    group: vagrant
+    mode: '0775'
+
+- name: Create hello_loop.sh from .j2 template
+  template:
+    src: templates/hello_loop.sh.j2
+    dest: /home/vagrant/scripts/hello_loop.sh
+    owner: vagrant
+    group: vagrant
+    mode: '0775'
+
+- name: Create if_statement.sh from .j2 template
+  template:
+    src: templates/if_statement.sh.j2
+    dest: /home/vagrant/scripts/if_statement.sh
+    owner: vagrant
+    group: vagrant
+    mode: '0775'
+
+- name: Create basic_function.sh from .j2 template
+  template:
+    src: templates/basic_function.sh.j2
+    dest: /home/vagrant/scripts/basic_function.sh
+    owner: vagrant
+    group: vagrant
+    mode: '0775'

--- a/ansible/roles/basic-scripts/templates/basic_function.sh.j2
+++ b/ansible/roles/basic-scripts/templates/basic_function.sh.j2
@@ -1,0 +1,6 @@
+#!/bin/bash
+greet () {
+  echo "Hello $1 $2"
+}
+
+greet "John" "Doe"

--- a/ansible/roles/basic-scripts/templates/capture_input.sh.j2
+++ b/ansible/roles/basic-scripts/templates/capture_input.sh.j2
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Greet user and request their name
+echo "The activity generator"
+read -p "What is your name? " name
+
+# Create an array of activities
+activity[0]="Football"
+activity[1]="Table Tennis"
+activity[2]="8 Ball Pool"
+activity[3]="PS5"
+activity[6]="Blackjack"
+
+# Store the length of the array
+array_length=${#activity[0]}
+
+# Randomly select an index from 0 to array_length
+index=$(($RANDOM % $array_length))
+
+# Invite the user to join you participate in an activity
+echo "Hi" $name, "would you like to play" ${activity[$index]}"?"
+read -p "Answer: " answer

--- a/ansible/roles/basic-scripts/templates/hello_loop.sh.j2
+++ b/ansible/roles/basic-scripts/templates/hello_loop.sh.j2
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for name in Alice Bob Charlie; do
+  echo "Hello, $name!"
+done

--- a/ansible/roles/basic-scripts/templates/if_statement.sh.j2
+++ b/ansible/roles/basic-scripts/templates/if_statement.sh.j2
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+read -p "Give me a number: " number
+if [ $number -gt 10 ];
+then
+  echo "Your number is greater than 10."
+fi

--- a/ansible/roles/basic-scripts/templates/my_script.sh.j2
+++ b/ansible/roles/basic-scripts/templates/my_script.sh.j2
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "Hello, World!"
+
+name="Ashley"
+echo "Greetings, $name!"

--- a/ansible/vagrant-inventory/host_vars/centos-7.yml
+++ b/ansible/vagrant-inventory/host_vars/centos-7.yml
@@ -1,0 +1,1 @@
+ansible_python_interpreter: /usr/bin/python


### PR DESCRIPTION
- I kept running into this issue:
```
TASK [basic-scripts : Create capture_input.sh from .j2 template] ****************************************************************************
task path: /home/ashleyahoy/test_folder/ashley_ansible/ansible/roles/basic-scripts/tasks/main.yml:25
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: . Missing end of comment tag
fatal: [ubuntu-jammy]: FAILED! => {"changed": false, "msg": "AnsibleError: template error while templating string: Missing end of comment tag. String: #!/bin/bash\n\n# Greet user and request their name\necho \"The activity generator\"\nread -p \"What is your name? \" name\n\n# Create an array of activities\nactivity[0]=\"Football\"\nactivity[1]=\"Table Tennis\"\nactivity[2]=\"8 Ball Pool\"\nactivity[3]=\"PS5\"\nactivity[6]=\"Blackjack\"\n\n# Store the length of the array\narray_length=${#activity[0]}\n\n# Randomly select an index from 0 to array_length\nindex=$(($RANDOM % $array_length))\n\n# Invite the user to join you participate in an activity\necho \"Hi\" $name, \"would you like to play\" ${activity[$index]}\"?\"\nread -p \"Answer: \" answer\n. Missing end of comment tag"}
```
when trying to put this script on a host:
```

echo "The activity generator"
read -p "What is your name? " name

activity[0]="Football"
activity[1]="Table Tennis"
activity[2]="8 Ball Pool"
activity[3]="PS5"
activity[6]="Blackjack"

array_length=${#activity[0]}

index=$(($RANDOM % $array_length))

echo "Hi" $name, "would you like to play" ${activity[$index]}"?"
read -p "Answer: " answer
```

- The error persisted whether I tried putting the script on a remote host from a .j2 template or by using `blockinfile:`. The answer is likely [this](https://stackoverflow.com/questions/58845530/jinja-escaping-beginning-of-comment-tag). I'll try the suggested change to the script in a future branch.

- Created a host_vars file for centos-7 so it's python interpreter is `ansible_python_interpreter: /usr/bin/python` due to this error:
```
TASK [Gathering Facts] *****************************************************************************************************************
task path: /home/ashleyahoy/test_folder/ashley_ansible/ansible/put-basic-scripts-on-hosts.yml:2
fatal: [centos-7]: FAILED! => {"ansible_facts": {}, "changed": false, "failed_modules": {"ansible.legacy.setup": {"failed": true, "module_stderr": "Shared connection to 192.168.56.7 closed.\r\n", "module_stdout": "/bin/sh: /usr/bin/python3: No such file or directory\r\n", "msg": "The module failed to execute correctly, you probably need to set the interpreter.\nSee stdout/stderr for the exact error", "rc": 127}}, "msg": "The following modules failed to execute: ansible.legacy.setup\n"}
```